### PR TITLE
Added tray icon system & shortcut creation

### DIFF
--- a/MemSubLoader.cbp
+++ b/MemSubLoader.cbp
@@ -60,6 +60,8 @@
 			<Add library="Shlwapi" />
 			<Add library="Comdlg32" />
 			<Add library="gdiplus" />
+			<Add library="ole32" />
+			<Add library="uuid" />
 		</Linker>
 		<Unit filename="includes/MemSubLoader.hpp">
 			<Option target="Debug" />

--- a/includes/MemSubLoader.hpp
+++ b/includes/MemSubLoader.hpp
@@ -6,6 +6,8 @@
 # define _WIN32_WINNT 0x0501
 # define _WIN32_IE 0x0300
 # include <windows.h>
+# include <objidl.h>
+# include <objbase.h>
 # include <commctrl.h>
 # include <iostream>
 # include <shlwapi.h>
@@ -32,49 +34,50 @@
 # define MENU_LOAD 6
 # define MENU_SAVE 7
 # define MENU_SETAUTOLOAD 8
-# define MENU_EXIT 9
-# define MENU_SETTINGS 10
+# define MENU_CREATESHORTCUT 9
+# define MENU_EXIT 10
+# define MENU_SETTINGS 11
 
 // Settings controls
-# define FONT_COLOR_BUTTON 11
-# define FONT_BUTTON 12
-# define FONT_COLOR_ALPHA_EDIT 13
-# define FONT_COLOR_ALPHA_UPDOWN 14
-# define ALIGNMENT_HORIZONTAL_COMBOBOX 15
-# define ALIGNMENT_VERTICAL_COMBOBOX 16
-# define OUTLINE_WIDTH_EDIT 17
-# define OUTLINE_WIDTH_UPDOWN 18
-# define OUTLINE_COLOR_BUTTON 19
-# define OUTLINE_COLOR_ALPHA_EDIT 20
-# define OUTLINE_COLOR_ALPHA_UPDOWN 21
-# define SHADOWS_COLOR_BUTTON 22
-# define SHADOWS_COLOR_ALPHA_EDIT 23
-# define SHADOWS_COLOR_ALPHA_UPDOWN 24
-# define SHADOWS_WIDTH_EDIT 25
-# define SHADOWS_WIDTH_UPDOWN 26
-# define SHADOWS_XOFFSET_EDIT 27
-# define SHADOWS_XOFFSET_UPDOWN 28
-# define SHADOWS_YOFFSET_EDIT 29
-# define SHADOWS_YOFFSET_UPDOWN 30
-# define SHADOWS_DIFFUSE_CHECKBOX 31
-# define AREA_XPOS_EDIT 32
-# define AREA_XPOS_UPDOWN 33
-# define AREA_YPOS_EDIT 34
-# define AREA_YPOS_UPDOWN 35
-# define AREA_WIDTH_EDIT 36
-# define AREA_WIDTH_UPDOWN 37
-# define AREA_HEIGHT_EDIT 38
-# define AREA_HEIGHT_UPDOWN 39
-# define AREA_PREVIEW_CHECKBOX 40
-# define CONFIGURATOR_EDIT_BUTTON 41
-# define CONFIGURATOR_NEW_BUTTON 42
-# define CONFIGURATOR_DELETE_BUTTON 43
-# define CONFIGURATOR_DUPLICATE_BUTTON 44
-# define CONFIGURATOR_TODEFAULT_BUTTON 45
+# define FONT_COLOR_BUTTON 12
+# define FONT_BUTTON 13
+# define FONT_COLOR_ALPHA_EDIT 14
+# define FONT_COLOR_ALPHA_UPDOWN 15
+# define ALIGNMENT_HORIZONTAL_COMBOBOX 16
+# define ALIGNMENT_VERTICAL_COMBOBOX 17
+# define OUTLINE_WIDTH_EDIT 18
+# define OUTLINE_WIDTH_UPDOWN 19
+# define OUTLINE_COLOR_BUTTON 20
+# define OUTLINE_COLOR_ALPHA_EDIT 21
+# define OUTLINE_COLOR_ALPHA_UPDOWN 22
+# define SHADOWS_COLOR_BUTTON 23
+# define SHADOWS_COLOR_ALPHA_EDIT 24
+# define SHADOWS_COLOR_ALPHA_UPDOWN 25
+# define SHADOWS_WIDTH_EDIT 26
+# define SHADOWS_WIDTH_UPDOWN 27
+# define SHADOWS_XOFFSET_EDIT 28
+# define SHADOWS_XOFFSET_UPDOWN 29
+# define SHADOWS_YOFFSET_EDIT 30
+# define SHADOWS_YOFFSET_UPDOWN 31
+# define SHADOWS_DIFFUSE_CHECKBOX 32
+# define AREA_XPOS_EDIT 33
+# define AREA_XPOS_UPDOWN 34
+# define AREA_YPOS_EDIT 35
+# define AREA_YPOS_UPDOWN 36
+# define AREA_WIDTH_EDIT 37
+# define AREA_WIDTH_UPDOWN 38
+# define AREA_HEIGHT_EDIT 39
+# define AREA_HEIGHT_UPDOWN 40
+# define AREA_PREVIEW_CHECKBOX 41
+# define CONFIGURATOR_EDIT_BUTTON 42
+# define CONFIGURATOR_NEW_BUTTON 43
+# define CONFIGURATOR_DELETE_BUTTON 44
+# define CONFIGURATOR_DUPLICATE_BUTTON 45
+# define CONFIGURATOR_TODEFAULT_BUTTON 46
 
 // Save & Cancel controls
-# define SAVE_BUTTON 46
-# define CANCEL_BUTTON 47
+# define SAVE_BUTTON 47
+# define CANCEL_BUTTON 48
 
 # define FONT_ALPHA_MIN 0
 # define FONT_ALPHA_MAX 255
@@ -171,9 +174,11 @@ struct Subtitles
 // Global variables definition
 
 // Global resources
+
 extern std::vector <Subtitles> subtitles;
 extern std::wstring SubInfo;
 extern std::map<wchar_t *, Config, WStringCompare> configs;
+extern std::wstring loadedConfig;
 extern std::wstring textToDraw;
 extern std::wstring testidentifier;
 extern Config tmpConfig;
@@ -186,7 +191,6 @@ extern int screenHeight;
 extern int sub;
 extern int subID;
 extern bool isGameOpened;
-
 
 // Windows
 extern HWND mainHWND;
@@ -264,7 +268,6 @@ LRESULT CALLBACK ConfiguratorWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPA
 
 // Utilities
 std::wstring jsonUnicodeToWstring(const Json::Value& value);
-
 void findAddress(uintptr_t &address, int offset, HANDLE hProcess);
 
 bool openFileExplorer(HWND hwnd, wchar_t *filePath, int filePathSize, int button);
@@ -289,6 +292,10 @@ wchar_t *getSelectedIdentifier(void);
 void cleanup(void);
 
 // Game
-void gameStart(PROCESS_INFORMATION pi);
+void startGame(HWND hwnd);
+void scanGame(PROCESS_INFORMATION pi);
+
+// Shortcut
+bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const wchar_t *workingDir, const wchar_t *shortcutPath);
 
 #endif

--- a/includes/MemSubLoader.hpp
+++ b/includes/MemSubLoader.hpp
@@ -8,6 +8,7 @@
 # include <windows.h>
 # include <objidl.h>
 # include <objbase.h>
+# include <shellapi.h>
 # include <commctrl.h>
 # include <iostream>
 # include <shlwapi.h>
@@ -74,6 +75,11 @@
 # define CONFIGURATOR_DELETE_BUTTON 44
 # define CONFIGURATOR_DUPLICATE_BUTTON 45
 # define CONFIGURATOR_TODEFAULT_BUTTON 46
+
+// Tray controls
+# define TRAY_SHOW 47
+# define TRAY_OPEN 48
+# define TRAY_EXIT 49
 
 // Save & Cancel controls
 # define SAVE_BUTTON 47
@@ -198,6 +204,10 @@ extern HWND subtitlesHWND;
 extern HWND settingsHWND;
 extern HWND configuratorHWND;
 
+// Tray
+extern NOTIFYICONDATA niData;
+extern bool isTrayVisible;
+
 // Main window handles
 extern HWND gamePathValueLabel;
 extern HWND subtitlesPathValueLabel;
@@ -291,11 +301,15 @@ wchar_t *getSelectedIdentifier(void);
 
 void cleanup(void);
 
+// Shortcut
+bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const wchar_t *workingDir, const wchar_t *shortcutPath);
+
+// Tray
+void AddTrayIcon(HWND hWnd, HINSTANCE hInstance);
+void RemoveTrayIcon();
+
 // Game
 void startGame(HWND hwnd);
 void scanGame(PROCESS_INFORMATION pi);
-
-// Shortcut
-bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const wchar_t *workingDir, const wchar_t *shortcutPath);
 
 #endif

--- a/includes/MemSubLoader.hpp
+++ b/includes/MemSubLoader.hpp
@@ -173,8 +173,8 @@ struct Subtitles
 		bool is_playing;
 		std::vector <Dialog> dialog;
 
-		void search_memory(HANDLE hProcess);
-		bool check_audio(HANDLE hProcess, int place);
+		void searchMemory(HANDLE hProcess);
+		bool checkAudio(HANDLE hProcess, int place);
 };
 
 // Global variables definition
@@ -286,7 +286,7 @@ bool openColorDialog(HWND hwnd, COLORREF &subtitlesColor);
 
 void invalidateWindow(HWND hwnd);
 
-bool SubtitlesLoad(wchar_t *fileName);
+bool loadSubtitles(wchar_t *fileName);
 
 bool saveConfig(wchar_t *filename);
 bool loadConfig(const wchar_t *filename);
@@ -305,8 +305,8 @@ void cleanup(void);
 bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const wchar_t *workingDir, const wchar_t *shortcutPath);
 
 // Tray
-void AddTrayIcon(HWND hWnd, HINSTANCE hInstance);
-void RemoveTrayIcon();
+void addTrayIcon(HWND hWnd, HINSTANCE hInstance);
+void removeTrayIcon();
 
 // Game
 void startGame(HWND hwnd);

--- a/resources/MemSubLoader.rc
+++ b/resources/MemSubLoader.rc
@@ -36,6 +36,7 @@ MAIN_MENU MENU
     {
         MENUITEM "Load configuration", 0
         MENUITEM "Save configuration", 0
+		MENUITEM "Create shortcut using loaded config", 0
         MENUITEM "Set autoloaded configuration", 0
         MENUITEM SEPARATOR
         MENUITEM "Exit", 0

--- a/srcs/game.cpp
+++ b/srcs/game.cpp
@@ -47,8 +47,8 @@ void scanGame(PROCESS_INFORMATION pi)
                 for(int i = 0; i < num; i++)
                 {
 
-                    subtitles[i].search_memory(pi.hProcess);
-                    if (subtitles[i].check_audio(pi.hProcess, i))
+                    subtitles[i].searchMemory(pi.hProcess);
+                    if (subtitles[i].checkAudio(pi.hProcess, i))
                         is = true;
 
                 }

--- a/srcs/game.cpp
+++ b/srcs/game.cpp
@@ -1,7 +1,30 @@
 #include "MemSubLoader.hpp"
 
-// Used when the game starts
-void gameStart(PROCESS_INFORMATION pi)
+// Initialize subtitles windows then start the game
+void startGame(HWND hwnd)
+{
+	STARTUPINFO si;
+	PROCESS_INFORMATION pi;
+
+	ZeroMemory(&si, sizeof(si));
+	si.cb = sizeof(si);
+	ZeroMemory(&pi, sizeof(pi));
+
+	// Opens the game
+	CreateProcess(gamePath, NULL, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
+	WaitForInputIdle(pi.hProcess, INFINITE);
+
+	if (createSubtitlesWindow())
+	{
+		MessageBox(hwnd, L"Error: Failed to initialize subtitles window", L"Window initialization", MB_ICONERROR);
+	}
+
+	PostMessage(hwnd, WM_SYSCOMMAND, SC_MINIMIZE, 0);
+	scanGame(pi);
+}
+
+// Where the magic happens, scans memory for memory adresses accesses and draw subtitles accordingly
+void scanGame(PROCESS_INFORMATION pi)
 {
     int num = subtitles.size();
     int currentTimer = 1;

--- a/srcs/game.cpp
+++ b/srcs/game.cpp
@@ -92,4 +92,9 @@ void scanGame(PROCESS_INFORMATION pi)
 	CloseHandle(pi.hThread);
 	DestroyWindow(subtitlesHWND);
 	isGameOpened = false;
+
+	if (isTrayVisible)
+	{
+		ShowWindow(mainHWND, SW_SHOW); // Restore window
+	}
 }

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -5,6 +5,7 @@ using namespace Gdiplus;
 
 // Global resources
 std::map<wchar_t *, Config, WStringCompare> configs;
+std::wstring loadedConfig;
 std::wstring textToDraw;
 std::wstring testidentifier;
 Config tmpConfig = {};
@@ -74,18 +75,18 @@ int oldAreaHeight = 0;
 // Main
 int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
 {
-    LPWSTR *ArgList;
-    int nArgs;
+	LPWSTR *ArgList;
+	int nArgs;
 	hInst = hInstance;
 	MSG msg = {};
 	wchar_t autoloadPath[MAX_PATH] = {};
 	wchar_t message[MAX_PATH + 256] = {};
 	Config defaultConfig;
 
-    //Check arguments
-    ArgList = CommandLineToArgvW(GetCommandLineW(), &nArgs);
-    if(ArgList == NULL)
-        MessageBox(NULL, L"Error: Failed to check arguments", L"Arguments check", MB_ICONERROR);
+	// Check arguments
+	ArgList = CommandLineToArgvW(GetCommandLineW(), &nArgs);
+	if(ArgList == NULL)
+		MessageBox(NULL, L"Error: Failed to check arguments", L"Arguments check", MB_ICONERROR);
 
 	GpStatus gdiplusStatus = GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
 	if (gdiplusStatus != GpStatus::Ok)
@@ -94,70 +95,67 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 		cleanup();
 		return 1;
 	}
+
 	setDefaultConfig(defaultConfig);
-	if (getAutoloadConfigPath(autoloadPath)) // Get autoloaded configuration path from autoload.dat
+
+	// Autoload config using file argument
+	if(nArgs > 1 && wcsstr(ArgList[1], L"-config") && ArgList[2])
 	{
-		if (loadConfig(autoloadPath)) // Failed to load configuration
+		if (loadConfig(ArgList[2]))
 		{
-			wchar_t autoload[MAX_PATH];
-			if (getAutoloadPath(autoload))
-			{
-				DeleteFile(autoload);
-			}
-			wsprintf(message, L"Failed to autoload configuration :\n%s\nDeleted configuration autoload", autoloadPath);
+			wsprintf(message, L"Failed to autoload configuration.\n%s\nAborting.", autoloadPath);
 			MessageBox(NULL, message, L"Configuration autoloading", MB_ICONERROR);
+			cleanup();
+			return 1;
+		}
+		if (gamePath[0] == L'\0' || subtitlesPath[0] == L'\0')
+		{
+			MessageBox(NULL, L"Missing game or subtitles path in your autoloaded configuration file. Please check if both path are correct and try again.", L"Configuration autoloading", MB_ICONERROR);
+			cleanup();
+			return 1;
+		}
+		if (SubtitlesLoad(subtitlesPath))
+		{
+			MessageBox(NULL, L"Failed to load subtitles file", L"Subtitles loading", MB_ICONERROR);
+			subtitlesPath[0] = '\0';
+		}
+		startGame(NULL); // We're directly starting the game without creating the main window
+	}
+	else
+	{
+		int res = createMainWindow(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
+		if (res)
+		{
+			MessageBox(NULL, L"Error: Failed to initialize main window", L"Window initialization", MB_ICONERROR);
+			cleanup();
+			return 1;
+		}
+
+		// Autoload config using autoload.dat
+		if (getAutoloadConfigPath(autoloadPath)) // Get autoloaded configuration path from autoload.dat
+		{
+			if (loadConfig(autoloadPath)) // Failed to load configuration
+			{
+				wchar_t autoload[MAX_PATH];
+				if (getAutoloadPath(autoload))
+				{
+					DeleteFile(autoload);
+				}
+				wsprintf(message, L"Failed to autoload configuration :\n%s\nDeleted configuration autoload", autoloadPath);
+				MessageBox(NULL, message, L"Configuration autoloading", MB_ICONERROR);
+				configs.insert({ wcsdup(L"DEFAULT"), defaultConfig });
+			}
+			if (SubtitlesLoad(subtitlesPath))
+			{
+				MessageBox(NULL, L"Failed to load subtitles file", L"Subtitles loading", MB_ICONERROR);
+				subtitlesPath[0] = '\0';
+			}
+		}
+		else // No autoload.dat found
+		{
 			configs.insert({ wcsdup(L"DEFAULT"), defaultConfig });
 		}
-		if(SubtitlesLoad(subtitlesPath))
-        {
-            MessageBox(NULL, L"Failed to load subtitles file", L"Configuration autoloading", MB_ICONERROR);
-            subtitlesPath[0] = '\0';
-        }
 	}
-	else // No autoload.dat found
-	{
-		configs.insert({ wcsdup(L"DEFAULT"), defaultConfig });
-	}
-	if(nArgs > 1 && wcsstr(ArgList[1], L"-translate"))
-    {
-        if (gamePath[0] != L'\0' && subtitlesPath[0] != L'\0')
-        {
-						STARTUPINFO si;
-						PROCESS_INFORMATION pi;
-
-						ZeroMemory(&si, sizeof(si));
-						si.cb = sizeof(si);
-						ZeroMemory(&pi, sizeof(pi));
-
-						// Opens the game
-						CreateProcess(gamePath, NULL, NULL, NULL, FALSE, 0, NULL, NULL, &si, &pi);
-						WaitForInputIdle(pi.hProcess, INFINITE);
-
-                        if(!IsWindow(subtitlesHWND))
-						{
-						    if (createSubtitlesWindow())
-                            {
-                                MessageBox(NULL, L"Error: Failed to initialize subtitles window", L"Window initialization", MB_ICONERROR);
-                            }
-						}
-						gameStart(pi);
-        }
-        else
-        {
-            MessageBox(NULL, message, L"Something went wrong :(", MB_ICONERROR);
-        }
-        return 0;
-    }
-    else
-    {
-        int res = createMainWindow(hInstance, hPrevInstance, lpCmdLine, nCmdShow);
-        if (res)
-        {
-            MessageBox(NULL, L"Error: Failed to initialize main window", L"Window initialization", MB_ICONERROR);
-            cleanup();
-            return 1;
-        }
-    }
 
 	while (GetMessage(&msg, NULL, 0, 0) > 0)
 	{

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -121,7 +121,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 			cleanup();
 			return 1;
 		}
-		if (SubtitlesLoad(subtitlesPath))
+		if (loadSubtitles(subtitlesPath))
 		{
 			MessageBox(NULL, L"Failed to load subtitles file", L"Subtitles loading", MB_ICONERROR);
 			subtitlesPath[0] = '\0';
@@ -144,7 +144,7 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine
 				MessageBox(NULL, message, L"Configuration autoloading", MB_ICONERROR);
 				configs.insert({ wcsdup(L"DEFAULT"), defaultConfig });
 			}
-			if (SubtitlesLoad(subtitlesPath))
+			if (loadSubtitles(subtitlesPath))
 			{
 				MessageBox(NULL, L"Failed to load subtitles file", L"Subtitles loading", MB_ICONERROR);
 				subtitlesPath[0] = '\0';

--- a/srcs/mainWindow.cpp
+++ b/srcs/mainWindow.cpp
@@ -17,12 +17,12 @@ LRESULT CALLBACK mainWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 		{
 			if (wParam == SIZE_MINIMIZED)
 			{
-				AddTrayIcon(hwnd, GetModuleHandle(NULL));
+				addTrayIcon(hwnd, GetModuleHandle(NULL));
 				ShowWindow(hwnd, SW_HIDE); // Hide window in taskbar
 			}
 			else if (isTrayVisible)
 			{
-				RemoveTrayIcon();
+				removeTrayIcon();
 			}
 		}
 		break;
@@ -43,7 +43,7 @@ LRESULT CALLBACK mainWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 					if (openFileExplorer(hwnd, subtitlesPath, MAX_PATH, LOWORD(wParam)))
 					{
 						SetWindowText(subtitlesPathValueLabel, subtitlesPath);
-						if(SubtitlesLoad(subtitlesPath))
+						if(loadSubtitles(subtitlesPath))
 							{
 								MessageBox(hwnd, L"Failed to load subtitles file", L"Configuration autoloading", MB_ICONERROR);
 								subtitlesPath[0] = '\0';
@@ -221,7 +221,7 @@ LRESULT CALLBACK mainWindowProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPar
 
 		case WM_DESTROY:
 		{
-			RemoveTrayIcon();
+			removeTrayIcon();
 			PostQuitMessage(0);
 		}
 		break;

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -5,11 +5,11 @@ std::wstring SubInfo;
 
 std::wstring jsonUnicodeToWstring(const Json::Value& value)
 {
-    std::string str = value.asString();
-    int wstrLength = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
-    std::wstring wstr(wstrLength, 0);
-    MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], wstrLength);
-    return wstr;
+	std::string str = value.asString();
+	int wstrLength = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, nullptr, 0);
+	std::wstring wstr(wstrLength, 0);
+	MultiByteToWideChar(CP_UTF8, 0, str.c_str(), -1, &wstr[0], wstrLength);
+	return wstr;
 }
 
 // Find address containing audio ID
@@ -34,7 +34,7 @@ bool Subtitles::check_audio(HANDLE hProcess, int place)
 {
 	SIZE_T bytesRead;
 	ReadProcessMemory(hProcess, (LPCVOID)address_play, &is_playing, 1, &bytesRead);
-    ReadProcessMemory(hProcess, (LPCVOID)address_audio, &AudioID, 4, &bytesRead);
+	ReadProcessMemory(hProcess, (LPCVOID)address_audio, &AudioID, 4, &bytesRead);
 
 	if (is_playing)
 	{
@@ -45,18 +45,18 @@ bool Subtitles::check_audio(HANDLE hProcess, int place)
 			{
 				if (AudioID == dialog[i].ID)
 				{
-				    if(dialog[i].Timer.size() == 0)
-                    {
-                        textToDraw = dialog[i].Text[0];
-                    }
-                    else
-                    {
-                        textToDraw = L"";
-                        KillTimer(mainHWND,1);
-                        sub = place;
-                        subID = i;
-                        SetTimer(mainHWND, 2, dialog[i].Timer[0],NULL);
-                    }
+					if(dialog[i].Timer.size() == 0)
+					{
+						textToDraw = dialog[i].Text[0];
+					}
+					else
+					{
+						textToDraw = L"";
+						KillTimer(mainHWND,1);
+						sub = place;
+						subID = i;
+						SetTimer(mainHWND, 2, dialog[i].Timer[0],NULL);
+					}
 					testidentifier = dialog[i].identifier;
 					invalidateWindow(subtitlesHWND);
 					break;
@@ -66,16 +66,16 @@ bool Subtitles::check_audio(HANDLE hProcess, int place)
 		return true;
 	}
 	else
-    {
-        lastAudioID = 0;
-        return false;
-    }
+	{
+		lastAudioID = 0;
+		return false;
+	}
 }
 
 bool SubtitlesLoad(wchar_t *fileName)
 {
-    subtitles.clear();
-    std::ifstream inputFile(fileName);
+	subtitles.clear();
+	std::ifstream inputFile(fileName);
 	if (!inputFile.is_open()) {
 		return true;
 	}
@@ -92,204 +92,204 @@ bool SubtitlesLoad(wchar_t *fileName)
 	}
 	if(root.isMember("Addresses"))
 	{
-	    for(int i = 0; i < root["Addresses"].size(); i++)
-	    {
-	        subtitles.push_back(Subtitles());
-	        Json::Value address;
-	        address = root["Addresses"][i];
+		for(int i = 0; i < root["Addresses"].size(); i++)
+		{
+			subtitles.push_back(Subtitles());
+			Json::Value address;
+			address = root["Addresses"][i];
 
-	        subtitles[i].bAddress_audio = address["BaseAddressAudio"].asInt();
-	        for(int j = 0; j < address["OffsetsAudio"].size();j++)
-                subtitles[i].offset_audio.push_back(address["OffsetsAudio"][j].asInt());
+			subtitles[i].bAddress_audio = address["BaseAddressAudio"].asInt();
+			for(int j = 0; j < address["OffsetsAudio"].size();j++)
+				subtitles[i].offset_audio.push_back(address["OffsetsAudio"][j].asInt());
 
-            subtitles[i].bAddress_play = address["BaseAddressPlay"].asInt();
-	        for(int j = 0; j < address["OffsetsPlay"].size();j++)
-                subtitles[i].offset_play.push_back(address["OffsetsPlay"][j].asInt());
-	    }
+			subtitles[i].bAddress_play = address["BaseAddressPlay"].asInt();
+			for(int j = 0; j < address["OffsetsPlay"].size();j++)
+				subtitles[i].offset_play.push_back(address["OffsetsPlay"][j].asInt());
+		}
 	}
-    std::string sub = "Subtitles";
-    for(int i = 0; i < root["Addresses"].size(); i++)
-    {
-        if(root.isMember(sub+std::to_string(i)))
-        {
+	std::string sub = "Subtitles";
+	for(int i = 0; i < root["Addresses"].size(); i++)
+	{
+		if(root.isMember(sub+std::to_string(i)))
+		{
 
 
-            int s = root[sub+std::to_string(i)].size();
-            for(int j = 0; j< s; j++)
-            {
-                int id;
-                std::wstring ident;
-                std::vector<std::wstring> text;
-                std::vector<u_int> timer;
+			int s = root[sub+std::to_string(i)].size();
+			for(int j = 0; j< s; j++)
+			{
+				int id;
+				std::wstring ident;
+				std::vector<std::wstring> text;
+				std::vector<u_int> timer;
 
-                Json::Value dialog;
-                dialog =root[sub+std::to_string(i)][j];
-                if(dialog.isMember("ID"))
-                {
-                    id = dialog["ID"].asUInt();
-                }
+				Json::Value dialog;
+				dialog =root[sub+std::to_string(i)][j];
+				if(dialog.isMember("ID"))
+				{
+					id = dialog["ID"].asUInt();
+				}
 
-                if(dialog.isMember("Identifier"))
-                {
-                    const std::string identString = dialog["Identifier"].asString();
-                    const std::wstring identWString(identString.begin(), identString.end());
-                    ident = identWString;
-                }
+				if(dialog.isMember("Identifier"))
+				{
+					const std::string identString = dialog["Identifier"].asString();
+					const std::wstring identWString(identString.begin(), identString.end());
+					ident = identWString;
+				}
 
-                if(dialog.isMember("Text"))
-                {
-                    Json::Value subs = dialog["Text"];
-                    if(subs.size() == 0)
-                    {
-                        const std::wstring textWString = jsonUnicodeToWstring(subs);
-                        text.push_back(textWString);
-                    }
-                    else
-                    for(int j = 0; j < subs.size();j++)
-                    {
-                        const std::wstring textWString = jsonUnicodeToWstring(subs[j]);
-                        text.push_back(textWString);
-                    }
-                }
+				if(dialog.isMember("Text"))
+				{
+					Json::Value subs = dialog["Text"];
+					if(subs.size() == 0)
+					{
+						const std::wstring textWString = jsonUnicodeToWstring(subs);
+						text.push_back(textWString);
+					}
+					else
+					for(int j = 0; j < subs.size();j++)
+					{
+						const std::wstring textWString = jsonUnicodeToWstring(subs[j]);
+						text.push_back(textWString);
+					}
+				}
 
-                if(dialog.isMember("Timer"))
-                {
-                    Json::Value time = dialog["Timer"];
-                    if(time.size() == 0)
-                    {
-                        timer.push_back(time.asInt());
-                    }
-                    else
-                    for(int j = 0; j < time.size();j++)
-                    {
-                        timer.push_back(time[j].asInt());
-                    }
-                }
-                Dialog test = {id,text,timer,ident};
-                subtitles[i].dialog.push_back(test);
+				if(dialog.isMember("Timer"))
+				{
+					Json::Value time = dialog["Timer"];
+					if(time.size() == 0)
+					{
+						timer.push_back(time.asInt());
+					}
+					else
+					for(int j = 0; j < time.size();j++)
+					{
+						timer.push_back(time[j].asInt());
+					}
+				}
+				Dialog test = {id,text,timer,ident};
+				subtitles[i].dialog.push_back(test);
 
-            }
-        }
-    }
+			}
+		}
+	}
 
-    if(root.isMember("Info"))
-    {
-        const std::wstring textWString = jsonUnicodeToWstring(root["Info"]);
-        SubInfo = textWString;
-        std::wcout<<SubInfo;
-    }
+	if(root.isMember("Info"))
+	{
+		const std::wstring textWString = jsonUnicodeToWstring(root["Info"]);
+		SubInfo = textWString;
+		std::wcout<<SubInfo;
+	}
 
-    if(root.isMember("Identifiers"))
-    {
-        root = root["Identifiers"];
-        //configs.clear();
-        for (Json::Value::const_iterator itr = root.begin(); itr != root.end(); ++itr) {
-            const std::string identifierString = itr.key().asString();
+	if(root.isMember("Identifiers"))
+	{
+		root = root["Identifiers"];
+		//configs.clear();
+		for (Json::Value::const_iterator itr = root.begin(); itr != root.end(); ++itr) {
+			const std::string identifierString = itr.key().asString();
 
-            const std::wstring identifierWString(identifierString.begin(), identifierString.end());
-            wchar_t *identifier = wcsdup(identifierWString.c_str());
+			const std::wstring identifierWString(identifierString.begin(), identifierString.end());
+			wchar_t *identifier = wcsdup(identifierWString.c_str());
 
-            if(identifier == configs[identifier].identifier)
-                continue;
+			if(identifier == configs[identifier].identifier)
+				continue;
 
-            const Json::Value &configObject = *itr;
-            Config config;
+			const Json::Value &configObject = *itr;
+			Config config;
 
-            config.identifier = identifier;
+			config.identifier = identifier;
 
-            // Font
-            if (configObject.isMember("fontColor")) {
-                config.fontColor = static_cast<COLORREF>(configObject["fontColor"].asUInt());
-            }
-            if (configObject.isMember("fontColorAlpha")) {
-                config.fontColorAlpha = configObject["fontColorAlpha"].asInt();
-            }
-            if (configObject.isMember("fontFaceName") && configObject["fontFaceName"].isString()) {
-                if (configObject["fontFaceName"].size() < LF_FACESIZE) {
-                    std::string faceNameString = configObject["fontFaceName"].asString();
-                    std::wstring wFaceName = std::wstring(faceNameString.begin(), faceNameString.end());
-                    wcsncpy(config.subtitlesFont.lfFaceName, wFaceName.c_str(), LF_FACESIZE);
-                }
-            }
-            if (configObject.isMember("fontHeight")) {
-                config.subtitlesFont.lfHeight = configObject["fontHeight"].asInt();
-            }
+			// Font
+			if (configObject.isMember("fontColor")) {
+				config.fontColor = static_cast<COLORREF>(configObject["fontColor"].asUInt());
+			}
+			if (configObject.isMember("fontColorAlpha")) {
+				config.fontColorAlpha = configObject["fontColorAlpha"].asInt();
+			}
+			if (configObject.isMember("fontFaceName") && configObject["fontFaceName"].isString()) {
+				if (configObject["fontFaceName"].size() < LF_FACESIZE) {
+					std::string faceNameString = configObject["fontFaceName"].asString();
+					std::wstring wFaceName = std::wstring(faceNameString.begin(), faceNameString.end());
+					wcsncpy(config.subtitlesFont.lfFaceName, wFaceName.c_str(), LF_FACESIZE);
+				}
+			}
+			if (configObject.isMember("fontHeight")) {
+				config.subtitlesFont.lfHeight = configObject["fontHeight"].asInt();
+			}
 
-            if (configObject.isMember("fontWeight")) {
-                config.subtitlesFont.lfWeight = configObject["fontWeight"].asInt();
-            }
+			if (configObject.isMember("fontWeight")) {
+				config.subtitlesFont.lfWeight = configObject["fontWeight"].asInt();
+			}
 
-            if (configObject.isMember("fontItalic")) {
-                config.subtitlesFont.lfItalic = configObject["fontItalic"].asBool();
-            }
+			if (configObject.isMember("fontItalic")) {
+				config.subtitlesFont.lfItalic = configObject["fontItalic"].asBool();
+			}
 
-            if (configObject.isMember("fontUnderline")) {
-                config.subtitlesFont.lfUnderline = configObject["fontUnderline"].asBool();
-            }
+			if (configObject.isMember("fontUnderline")) {
+				config.subtitlesFont.lfUnderline = configObject["fontUnderline"].asBool();
+			}
 
-            if (configObject.isMember("fontStrikeout")) {
-                config.subtitlesFont.lfStrikeOut = configObject["fontStrikeout"].asBool();
-            }
+			if (configObject.isMember("fontStrikeout")) {
+				config.subtitlesFont.lfStrikeOut = configObject["fontStrikeout"].asBool();
+			}
 
-            // Alignement
-            if (configObject.isMember("horizontalAlignment")) {
-                config.horizontalAlignment = static_cast<TextAlignment>(configObject["horizontalAlignment"].asInt());
-            }
-            if (configObject.isMember("verticalAlignment")) {
-                config.verticalAlignment = static_cast<TextAlignment>(configObject["verticalAlignment"].asInt());
-            }
+			// Alignement
+			if (configObject.isMember("horizontalAlignment")) {
+				config.horizontalAlignment = static_cast<TextAlignment>(configObject["horizontalAlignment"].asInt());
+			}
+			if (configObject.isMember("verticalAlignment")) {
+				config.verticalAlignment = static_cast<TextAlignment>(configObject["verticalAlignment"].asInt());
+			}
 
-            // Outline
-            if (configObject.isMember("outlineWidth")) {
-                config.outlineWidth = configObject["outlineWidth"].asInt();
-            }
-            if (configObject.isMember("outlineColor")) {
-                config.outlineColor = static_cast<COLORREF>(configObject["outlineColor"].asUInt());
-            }
-            if (configObject.isMember("outlineColorAlpha")) {
-                config.outlineColorAlpha = configObject["outlineColorAlpha"].asInt();
-            }
+			// Outline
+			if (configObject.isMember("outlineWidth")) {
+				config.outlineWidth = configObject["outlineWidth"].asInt();
+			}
+			if (configObject.isMember("outlineColor")) {
+				config.outlineColor = static_cast<COLORREF>(configObject["outlineColor"].asUInt());
+			}
+			if (configObject.isMember("outlineColorAlpha")) {
+				config.outlineColorAlpha = configObject["outlineColorAlpha"].asInt();
+			}
 
-            // Shadows
-            if (configObject.isMember("shadowsWidth")) {
-                config.shadowsWidth = configObject["shadowsWidth"].asInt();
-            }
-            if (configObject.isMember("shadowsColor")) {
-                config.shadowsColor = static_cast<COLORREF>(configObject["shadowsColor"].asUInt());
-            }
-            if (configObject.isMember("shadowsXOffset")) {
-                config.shadowsXOffset = configObject["shadowsXOffset"].asInt();
-            }
-            if (configObject.isMember("shadowsYOffset")) {
-                config.shadowsYOffset = configObject["shadowsYOffset"].asInt();
-            }
-            if (configObject.isMember("shadowsColorAlpha")) {
-                config.shadowsColorAlpha = configObject["shadowsColorAlpha"].asInt();
-            }
-            if (configObject.isMember("shadowsDiffuse")) {
-                config.shadowsDiffuse = configObject["shadowsDiffuse"].asInt();
-            }
+			// Shadows
+			if (configObject.isMember("shadowsWidth")) {
+				config.shadowsWidth = configObject["shadowsWidth"].asInt();
+			}
+			if (configObject.isMember("shadowsColor")) {
+				config.shadowsColor = static_cast<COLORREF>(configObject["shadowsColor"].asUInt());
+			}
+			if (configObject.isMember("shadowsXOffset")) {
+				config.shadowsXOffset = configObject["shadowsXOffset"].asInt();
+			}
+			if (configObject.isMember("shadowsYOffset")) {
+				config.shadowsYOffset = configObject["shadowsYOffset"].asInt();
+			}
+			if (configObject.isMember("shadowsColorAlpha")) {
+				config.shadowsColorAlpha = configObject["shadowsColorAlpha"].asInt();
+			}
+			if (configObject.isMember("shadowsDiffuse")) {
+				config.shadowsDiffuse = configObject["shadowsDiffuse"].asInt();
+			}
 
-            // Area
-            if (configObject.isMember("areaXPosition")) {
-                config.areaXPosition = configObject["areaXPosition"].asInt();
-            }
-            if (configObject.isMember("areaYPosition")) {
-                config.areaYPosition = configObject["areaYPosition"].asInt();
-            }
-            if (configObject.isMember("areaWidth")) {
-                config.areaWidth = configObject["areaWidth"].asInt();
-            }
-            if (configObject.isMember("areaHeight")) {
-                config.areaHeight = configObject["areaHeight"].asInt();
-            }
-            if (configObject.isMember("areaPreview")) {
-                config.areaPreview = configObject["areaPreview"].asInt();
-            }
-            checkConfig(config);
-            configs[identifier] = config;
-            }
-    }
+			// Area
+			if (configObject.isMember("areaXPosition")) {
+				config.areaXPosition = configObject["areaXPosition"].asInt();
+			}
+			if (configObject.isMember("areaYPosition")) {
+				config.areaYPosition = configObject["areaYPosition"].asInt();
+			}
+			if (configObject.isMember("areaWidth")) {
+				config.areaWidth = configObject["areaWidth"].asInt();
+			}
+			if (configObject.isMember("areaHeight")) {
+				config.areaHeight = configObject["areaHeight"].asInt();
+			}
+			if (configObject.isMember("areaPreview")) {
+				config.areaPreview = configObject["areaPreview"].asInt();
+			}
+			checkConfig(config);
+			configs[identifier] = config;
+			}
+	}
 	inputFile.close();
 	return false;
 }
@@ -766,14 +766,14 @@ void setDefaultConfig(Config &defaultConfig)
 
 void checkConfig(Config &config)
 {
-    if(config.areaXPosition > 100)
-        config.areaXPosition = 100;
-    if(config.areaYPosition > 100)
-        config.areaYPosition = 100;
-    if(config.areaWidth > 100)
-        config.areaWidth = 100;
-    if(config.areaHeight > 100)
-        config.areaHeight = 100;
+	if(config.areaXPosition > 100)
+		config.areaXPosition = 100;
+	if(config.areaYPosition > 100)
+		config.areaYPosition = 100;
+	if(config.areaWidth > 100)
+		config.areaWidth = 100;
+	if(config.areaHeight > 100)
+		config.areaHeight = 100;
 }
 
 wchar_t *getSelectedIdentifier(void)
@@ -859,4 +859,25 @@ bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const w
 	}
 	CoUninitialize();
 	return SUCCEEDED(hres);
+}
+
+void AddTrayIcon(HWND hWnd, HINSTANCE hInstance)
+{
+	niData.cbSize = sizeof(NOTIFYICONDATA);
+	niData.hWnd = hWnd;
+	niData.uID = 1; // Unique ID for the tray icon
+	niData.uFlags = NIF_ICON | NIF_MESSAGE | NIF_TIP;
+	niData.uCallbackMessage = TRAY_SHOW;
+	niData.hIcon = LoadIcon(hInstance, MAKEINTRESOURCE(MSL_ICON)); // Icon for the tray
+	lstrcpy(niData.szTip, L"MemSubLoader"); // Tooltip text
+	Shell_NotifyIcon(NIM_ADD, &niData);
+	isTrayVisible = true;
+}
+
+void RemoveTrayIcon()
+{
+	if (isTrayVisible) {
+		Shell_NotifyIcon(NIM_DELETE, &niData);
+		isTrayVisible = false;
+	}
 }

--- a/srcs/utils.cpp
+++ b/srcs/utils.cpp
@@ -20,7 +20,7 @@ void Subtitles::findAddress(uintptr_t &address, int offset, HANDLE hProcess)
 		address += offset;
 }
 
-void Subtitles::search_memory(HANDLE hProcess)
+void Subtitles::searchMemory(HANDLE hProcess)
 {
 	address_audio = bAddress_audio;
 	address_play = bAddress_play;
@@ -30,7 +30,7 @@ void Subtitles::search_memory(HANDLE hProcess)
 		findAddress(address_play,offset_play[i],hProcess);
 }
 
-bool Subtitles::check_audio(HANDLE hProcess, int place)
+bool Subtitles::checkAudio(HANDLE hProcess, int place)
 {
 	SIZE_T bytesRead;
 	ReadProcessMemory(hProcess, (LPCVOID)address_play, &is_playing, 1, &bytesRead);
@@ -72,7 +72,7 @@ bool Subtitles::check_audio(HANDLE hProcess, int place)
 	}
 }
 
-bool SubtitlesLoad(wchar_t *fileName)
+bool loadSubtitles(wchar_t *fileName)
 {
 	subtitles.clear();
 	std::ifstream inputFile(fileName);
@@ -861,7 +861,7 @@ bool createShortcut(const wchar_t *targetPath, const wchar_t *arguments, const w
 	return SUCCEEDED(hres);
 }
 
-void AddTrayIcon(HWND hWnd, HINSTANCE hInstance)
+void addTrayIcon(HWND hWnd, HINSTANCE hInstance)
 {
 	niData.cbSize = sizeof(NOTIFYICONDATA);
 	niData.hWnd = hWnd;
@@ -874,7 +874,7 @@ void AddTrayIcon(HWND hWnd, HINSTANCE hInstance)
 	isTrayVisible = true;
 }
 
-void RemoveTrayIcon()
+void removeTrayIcon()
 {
 	if (isTrayVisible) {
 		Shell_NotifyIcon(NIM_DELETE, &niData);


### PR DESCRIPTION
Tray icon will be automatically added/removed upon minimizing/restoring the window. The app will start minimized if -config flag is set properly.
To create a shortcut, you need to load/save a configuration file, which will populate the 'loadedConfig' variable, tracking the last loaded/saved config, and using it accordingly to target the file to load with the -config argument.